### PR TITLE
Pass image object or string as 'source' for drawImage

### DIFF
--- a/jcanvas.js
+++ b/jcanvas.js
@@ -549,11 +549,15 @@ $.fn.drawText = function(args) {
 
 // Draw image
 $.fn.drawImage = function(args) {
-	var ctx, elem, e, params = merge(new Prefs(), args),
-		// Define image source
-		img = new Image(),
-		scaleFac;
-	img.src = params.source;
+	var ctx, elem, e, params = merge(new Prefs(), args), img, scaleFac;
+
+       // Did we get an Image object or a (possibly data) url?
+       if(typeof params.source == 'string') {
+         img = new Image();
+         img.src = params.source;
+       } else {
+         img = params.source;
+       }
 
 	// Draw image function
 	function draw(ctx) {


### PR DESCRIPTION
I save a few cycles by handing in the pre-parsed Image() object.  As this use case is triggered by a mouse move event (and happens a lot), I think the savings make sense.

Thanks!

-- H
