### PR TITLE
Queue a new jCanvas layer in a forced order

### DIFF
--- a/jcanvas.js
+++ b/jcanvas.js
@@ -1326,6 +1326,29 @@ $.fn.addLayer = function(args) {
 	return $elems;
 };
 
+// Queue a new jCanvas layer in a forced order (using the "after" callback).
+//    Draw layers after all have been queued.
+$.fn.queueLayer = function(args) {
+	var $elems = this, $elem, e, ctx,
+		params = args || {};
+
+	for (e=0; e<$elems.length; e+=1) {
+		$elem = $($elems[e]);
+		ctx = loadCanvas($elem[e]);
+		if (ctx) {
+			params = addLayer($elem[0], params);
+		}
+	}
+	if (params.after === UNDEFINED) {
+		// no layers after this one, draw all layers
+		this.drawLayers();
+	} else if (typeof params.after === 'function') {
+		// queue the layer after this one
+		params.after.call();
+        }
+	return $elems;
+};
+
 // Remove all jCanvas layers
 $.fn.removeLayers = function() {
 	var $elems = this, layers, e;


### PR DESCRIPTION
Caleb,

We had a conversation on Twitter back on 30 April regarding forcing a layer order in jCanvas.  Your "load()" fn suggestion in that discussion seemed to only apply to "drawImage", which didn't meet my needs.  So I have now successfully used callbacks in this commit and a new jCanvas method called "queueLayer" (which uses your new 24 May "addLayer" internal function).

A callback approach is a bit messier than (for instance) providing the end user a z-order parameter, but I'm not a good enough jCanvas wizard to try to tackle an approach like that ;-)  I thought I'd share this code right away, I'll boil down example usage code and share it with you later if you're interested.

~ Dave (@dave_k_smith)
