### PR TITLE
Infinite looping on trying to set a maxWidth on single word text

### DIFF
--- a/jcanvas.js
+++ b/jcanvas.js
@@ -1639,8 +1639,9 @@ function wrapText(ctx, params) {
 		lines = [],
 		line = '';
 	
-	if (ctx.measureText(text).width < maxWidth) {
+	if (ctx.measureText(text).width < maxWidth || words.length == 1) {
 		// If text is short enough initially, do nothing else
+		// Or there is just one word, then just silently ignore maxWidth parameter.
 		lines = [text];
 	} else {
 		// Keep adding words to line until line is too long


### PR DESCRIPTION
While creating a text layer, trying to set maxWidth for a string which contains exactly one word and the ctx.measuretext.width of that text is larger than maxWidth then the current implementation results in an infinite loop because of faulty words breaking logic into array of lines. And the browser hangs as a result.

I know it could be argued that "setting a maxWidth for single word text" in itself is a bad idea. But a graceful failure here could be that drawLayer silently ignoring maxWidth in this case?
