### PR TITLE
Native jquery event data is needed in event handler methods

### DIFF
--- a/jcanvas.js
+++ b/jcanvas.js
@@ -1087,6 +1087,7 @@ function createEvent(eventName) {
 				eventCache.x = event.offsetX;
 				eventCache.y = event.offsetY;
 				eventCache.type = helperEventName;
+				eventCache.jquery_event = event
 				$elem.drawLayers(TRUE);
 				event.preventDefault();
 			});
@@ -1114,6 +1115,9 @@ function detectEvents(elem, ctx, layer) {
 	// Allow callback functions to retrieve the mouse coordinates
 	layer.mouseX = eventCache.x;
 	layer.mouseY = eventCache.y;
+
+	// Add native jquery event data in the fired event
+	layer.event = eventCache.jquery_event
 		
 	// Adjust coordinates to match current canvas transformation
 	


### PR DESCRIPTION
Currently the layer information is passed to the event handler methods. It does not have the native jquery event data though. So information like if option key was pressed, shift key was pressed etc are missing which limits the ways the event handlers could be used.

This patch is a bad way to expose the jquery event via the layer itself to the event handlers.

I suppose the right way is to pass the standard jquery event as the argument for the event handler with event.data pointing to the layer information. I tried to implement that but got lost a bit.
