### PR TITLE
Add shadowStroke property to shadow fill+stroke.

### DIFF
--- a/jcanvas.js
+++ b/jcanvas.js
@@ -102,6 +102,7 @@ defaults = {
 	scaleY: 1,
 	shadowBlur: 0,
 	shadowColor: 'transparent',
+	shadowStroke: false,
 	shadowX: 0,
 	shadowY: 0,
 	sHeight: NULL,
@@ -218,15 +219,26 @@ function _closePath(canvas, ctx, params) {
 	if (params.closed) {
 		ctx.closePath();
 	}
-	ctx.fill();
-	// Prevent extra shadow created by stroke (but only when fill is present)
-	if (params.fillStyle !== 'transparent') {
+  if(params.shadowStroke && params.strokeWidth !== 0) {
+		ctx.stroke(); // first the stroke with shadow
+	  ctx.fill();   // fill with shadow
+    // Re-stroke without shadow for shadow of fill+stroke 
 		ctx.shadowColor = 'transparent';
-	}
-	// Only stroke if the stroke
-	if (params.strokeWidth !== 0) {
-		ctx.stroke();
-	}
+    ctx.shadowOffsetX = 0;
+    ctx.shadowOffsetY = 0;
+    ctx.stroke(); // fix stroke without shadow
+  } else {
+	  ctx.fill();
+	  // Prevent extra shadow created by stroke (but only when fill is present)
+    // and not overriden with shadowStroke
+	  if (params.fillStyle !== 'transparent') {
+		  ctx.shadowColor = 'transparent';
+	  }
+	  // Only stroke if the stroke
+	  if (params.strokeWidth !== 0) {
+		  ctx.stroke();
+	  }
+  }
 	// Optionally close path
 	if (!params.closed) {
 		ctx.closePath();


### PR DESCRIPTION
The shadowStroke property is an optional boolean (true/false) that overrides the default behavior by creating a shadow for the stroke even when a fill is set.

The code makes an isolated change to the order of fill/stroke in _closePath
so that all support shapes are supported without impact to existing functionality.

This new property solves issue #93.
