### PR TITLE
Add event detection for the stroke of a shape

### DIFF
--- a/jcanvas.js
+++ b/jcanvas.js
@@ -1562,8 +1562,10 @@ function _detectEvents(canvas, ctx, params) {
 				
 		data = _getCanvasData(canvas);
 		eventCache = data.event;
-		over = ctx.isPointInPath(eventCache.x, eventCache.y)
-                    || ctx.isPointInStroke && ctx.isPointInStroke(eventCache.x, eventCache.y);
+    if (eventCache.hasOwnProperty('x') && eventCache.hasOwnProperty('y')) {
+		  over = ctx.isPointInPath(eventCache.x, eventCache.y)
+        || (ctx.isPointInStroke && ctx.isPointInStroke(eventCache.x, eventCache.y));
+    }
 		transforms = data.transforms;
 		
 		// Allow callback functions to retrieve the mouse coordinates


### PR DESCRIPTION
Event detection was only considering event points only within the path and not within the stroke.  This edit adds a check for "over" the path or the stroke, allowing both the trigger events.

The following [Sandbox spinning star illustration](http://calebevans.me/projects/jcanvas/sandbox/?code=%2F%2F%20Click%20the%20star%20to%20make%20it%20spin%0A%2F%2F%20But%20click%20the%20very%20tips%20is%20broken%0A%24%28%22canvas%22%29.drawPolygon%28%7B%0A%20%20layer%3A%20true%2C%0A%20%20fillStyle%3A%20%22%23c33%22%2C%0A%20%20strokeStyle%3A%20%22%23333%22%2C%0A%20%20strokeWidth%3A%20%2220%22%2C%0A%20%20x%3A%20100%2C%20y%3A%20100%2C%0A%20%20radius%3A%2050%2C%0A%20%20sides%3A%205%2C%0A%20%20projection%3A%20-0.5%2C%0A%20%20click%3A%20function%28layer%29%20%7B%0A%20%20%20%20%2F%2F%20Spin%20star%0A%20%20%20%20%24%28this%29.animateLayer%28layer%2C%20%7B%0A%20%20%20%20%20%20rotate%3A%20'%2B%3D144'%0A%20%20%20%20%7D%29%3B%0A%20%20%7D%0A%7D%29%3B) demonstrates the behavior. If you click at the very tip of the points, the click event won't register.  However, any click at least half-way inside the black stroke will register because it's also inside the path.

I think this is still a decent general purpose default, and I've implemented it that way. In the future, separating fill/stroke detection could be an option to consider. Right now, I think that's just cluttering the interface.

My use case has thousands of elements in a canvas and doesn't degrade for the path+stroke check.
