### PR TITLE
detectPixelRatio tweaks.

### DIFF
--- a/jcanvas.js
+++ b/jcanvas.js
@@ -3012,25 +3012,22 @@ $.fn.detectPixelRatio = function detectPixelRatio(callback) {
 			// Calculate general ratio based on the two given ratios
 			ratio = devicePixelRatio / backingStoreRatio;
 			
-			if (ratio !== 1) {
-				// Scale canvas relative to ratio
-				
-				// Get the current canvas dimensions for future use
-				oldWidth = canvas.width;
-				oldHeight = canvas.height;
+			// Scale canvas relative to ratio
+			
+			// Get the current canvas dimensions for future use
+			oldWidth = $canvas.outerWidth();
+			oldHeight = $canvas.outerHeight();
 
-				// Resize canvas relative to the determined ratio
-				canvas.width = oldWidth * ratio;
-				canvas.height = oldHeight * ratio;
-			
-				// Scale canvas back to original dimensions via CSS
-				canvas.style.width = oldWidth + 'px';
-				canvas.style.height = oldHeight + 'px';
-			
-				// Scale context to counter the manual scaling of canvas
-				ctx.scale(ratio, ratio);
-			
-			}
+			// Resize canvas relative to the determined ratio
+			canvas.width = oldWidth * ratio;
+			canvas.height = oldHeight * ratio;
+		
+			// Scale canvas back to original dimensions via CSS
+			canvas.style.width = oldWidth + 'px';
+			canvas.style.height = oldHeight + 'px';
+		
+			// Scale context to counter the manual scaling of canvas
+			ctx.scale(ratio, ratio);
 		
 			// Set pixel ratio on canvas data object
 			data.pixelRatio = ratio;


### PR DESCRIPTION
Always apply detectPixelRatio changed (if called) and use jQuery outerWidth/Height to get original height/width.

I only did a couple tests, but I was trying to draw on a Retina display, and I found that `detectPixelRatio` worked... but it shrunk my canvas. I changed it to use the `$canvas`'s `.outerWidth()` and `.outerHeight()` (via jQuery) to find the `oldWidth` and `oldHeight` and it worked perfectly (see line 3018).

Then I tested on a non-Retina computer, and the ratio was one (so that method doesn't actually make any changes), but it was all askew... I then remove the `if (ratio !== 1)` if statement and it worked flawlessly.

So I don't quite know what's going here or if this will "always" work...

I'm using [jCanvas](http://calebevans.me/projects/jcanvas/) to draw, but in my testing, it was drawing the same as the vanilla style (so I don't think it's why things are weird).

Just for completeness' sake, this is what I'm using to draw:

``` javascript
$this.bind('touchmove mousemove', function(event) {
    if(!isDrawing) return;

    var thisX = event.offsetX;
    var thisY = event.offsetY;

    $this.drawLine({
        strokeStyle: '#000',
        strokeWidth: 1,
        rounded: true,
        x1: lastX, y1: lastY,
        x2: thisX, y2: thisY
    });

    lastX = thisX;
    lastY = thisY;
});
```
