### PR TITLE
Leading zeroes should not be stripped

### DIFF
--- a/jcanvas.js
+++ b/jcanvas.js
@@ -186,7 +186,7 @@ function _coerceNumericProps( props ) {
 	var propName, propType, propValue;
 	// Loop through all properties in given property map
 	for ( propName in props ) {
-		if ( props.hasOwnProperty( propName ) ) {
+		if ( props.hasOwnProperty( propName ) && propName !== 'text' ) {
 			propValue = props[ propName ];
 			propType = typeOf( propValue );
 			// If property is non-empty string and value is numeric


### PR DESCRIPTION
Hello,

when calling the `drawText` method with numeric strings that begin with zero (such as `"001234"`), the leading zeroes are stripped (the displayed result is `"1234"`). It happens since there is an automatic number conversion in place. Could you please include this change to your project?

With best regards
—
Pavel Dvořák
