### PR TITLE
Fix for jcanvas & browserify

### DIFF
--- a/jcanvas.js
+++ b/jcanvas.js
@@ -6,7 +6,7 @@
 (function( jQuery, global, factory ) {
 
 	if ( typeof module === 'object' && typeof module.exports === 'object' ) {
-		module.exports = global.document ?
+		module.exports = global.document && typeof jQuery !== 'undefined' ?
 			factory( global, true ) :
 			function( jQuery, w ) {
 				return factory( jQuery, w );


### PR DESCRIPTION
As described in issue #201 jcanvas' factory receives non-working parameters when jcanvas is required via loader (e.g. using browserify) in browser.

This PR adds an additional check whether jQuery is defined. If not, the factory for injecting variables is retuned. This way jcanvas can be used in browsers with browserify bundling like this:

````
var $ = require('jquery');
require('jcanvas')($, window);
````