### PR TITLE
remove factory(global, true) codepath, it cannot really work

### DIFF
--- a/jcanvas.js
+++ b/jcanvas.js
@@ -6,11 +6,9 @@
 (function( jQuery, global, factory ) {
 
 	if ( typeof module === 'object' && typeof module.exports === 'object' ) {
-		module.exports = global.document && typeof jQuery !== 'undefined' ?
-			factory( global, true ) :
-			function( jQuery, w ) {
-				return factory( jQuery, w );
-			};
+		module.exports = function( jQuery, w ) {
+			return factory( jQuery, w );
+		};
 	} else {
 		factory( jQuery, global );
 	}


### PR DESCRIPTION
I would like to use jcanvas with browserify and I hit the same problem as in https://github.com/caleb531/jcanvas/issues/201

The fix implemented there does not work if jQuery has been included (for example from CDN) before the browserify bundle.

My suggestion is to completely remove the factor(global, true) codepath, because it does not seem to make any sense to pass a boolean as second parameter to factory - which then tries to access .window, Image, Array, etc properties on it.

The proposed change does fix my usecase and should not have any side effects either.