### PR TITLE
Account for jQuery no-conflict mode

### DIFF
--- a/jcanvas.js
+++ b/jcanvas.js
@@ -14,7 +14,7 @@
 	}
 
 // Pass this if window is not defined yet
-}( typeof window !== 'undefined' ? window.$ : {}, typeof window !== 'undefined' ? window : this, function( $, window ) {
+}( typeof window !== 'undefined' ? window.jQuery : {}, typeof window !== 'undefined' ? window : this, function( $, window ) {
 
 var document = window.document,
     Image = window.Image,


### PR DESCRIPTION
For instance, WordPress loads jQuery in no-conflict mode, so the `$` shortcut does not work, so we reference the `jQuery` object instead and pass it in as `$`. Otherwise, you can't use this plugin with WordPress.