### PR TITLE
bug fix:unable to load pattern via url

### DIFF
--- a/jcanvas.js
+++ b/jcanvas.js
@@ -4046,7 +4046,7 @@ $.fn.createPattern = function createPattern( args ) {
 			if ( img.complete || imgCtx ) {
 				onload();
 			} else {
-				img.onload = onload();
+				img.onload = onload;
 				// Fix onload() bug in IE9
 				img.src = img.src;
 			}


### PR DESCRIPTION
Line 4049 before change will cause error firing img.onload event.
if you test current (before change) code in debug, you may not find the error, because when pausing the code in debug ,img will be load in time and line 4049 will not run.
Not tested in IE, but reset img.src to empty before binding onload event may help in IE.