### PR TITLE
f.getClientRects is not a function in Safari/iOS

### DIFF
--- a/dist/jcanvas.js
+++ b/dist/jcanvas.js
@@ -2375,8 +2375,8 @@ $.event.fix = function (event) {
 
 		// If offsetX and offsetY are not supported, define them
 		if (event.pageX !== undefined && event.offsetX === undefined) {
-			offset = $(event.currentTarget).offset();
 			try {
+				offset = $(event.currentTarget).offset();
 				if (offset) {
 					event.offsetX = event.pageX - offset.left;
 					event.offsetY = event.pageY - offset.top;


### PR DESCRIPTION
Compatibility Issue with jQuery 3.0 in Safari/iOS

Exception with thrown value: TypeError: f.getClientRects is not a function. (In 'f.getClientRects()', 'f.getClientRects' is undefined)