### PR TITLE
Update jQuery dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "licenses": "MIT",
   "dependencies": {
-    "jquery": "^2.2.4"
+    "jquery": "^3.2.1"
   },
   "devDependencies": {
     "eslint": "^3.19.0",


### PR DESCRIPTION
jQuery 2.2.4 contains security vulnerabilities which results nsp flagging jcanvas as vulnerable. Can you update the jQuery dependency to version 3.2.1?